### PR TITLE
Add runtime-tools' validation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ script:
   - ./configure
   - make -j $(nproc)
   - make syntax-check
+  - make oci-runtime-validation

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,9 @@ srpm: dist-gzip crun.spec
 	$(MAKE) -C $(WD) dist-xz
 	rpmbuild -bs --define "_sourcedir $(WD)" --define "_specdir $(WD)" --define "_builddir $(WD)" --define "_srcrpmdir $(WD)" --define "_rpmdir $(WD)" --define "_buildrootdir $(WD)/.build" crun.spec
 
+oci-runtime-validation:
+	RUNTIME=$(CURDIR)/crun tests/oci-runtime-validation
+
 CLEANFILES = crun.spec
 
 libcrun_a_SOURCES = src/libcrun/utils.c \

--- a/tests/oci-runtime-validation
+++ b/tests/oci-runtime-validation
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Install and run runtime-tools' validation tests
+npm install -g tap
+go get -d -u github.com/opencontainers/runtime-tools || true
+
+cd $GOPATH/src/github.com/opencontainers/runtime-tools
+make
+sudo PATH="$PATH:$(dirname $(which node))" TAP="$(which tap)" RUNTIME="${RUNTIME}" make localvalidation \
+ || true # All tests don't pass yet. For now, only display results without returning an error.
+


### PR DESCRIPTION
For now, the results of the tests are printed without returning an error.

Signed-off-by: Alban Crequy <alban@kinvolk.io>

-----

This is similar to https://github.com/opencontainers/runc/pull/1758. But here I get this error:
```
writing file
'/sys/fs/cgroup/cpu,cpuacct/system.slice/libcrun-58f278ec-efa5-4587-bfb5-63b77347b69a/cgroup.procs':
No space left on device
```

I don't know what is this error but it reminds me of a [bug in the kernel](https://github.com/torvalds/linux/commit/24ee3cf89bef04e8bc23788aca4e029a3f0f06d9) fixed in Linux 4.2 and a [bug in Docker](https://github.com/docker/libcontainer/pull/642) fixed in Docker 1.8 (see also https://github.com/opencontainers/runc/issues/133 and https://github.com/rkt/rkt/issues/1210).