### PR TITLE
cgroup: initialize cpu subsystem

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -35,7 +35,7 @@
 #include <fcntl.h>
 #include <libgen.h>
 
-static const cgroups_subsystem_t cgroups_subsystems[] = { "cpuset", "devices", "pids", "memory",
+static const cgroups_subsystem_t cgroups_subsystems[] = { "cpuset", "cpu", "devices", "pids", "memory",
                                                           "net_cls,net_prio", "freezer", "blkio",
                                                           "hugetlb", "cpu,cpuacct", "perf_event",
                                                           "unified", NULL};


### PR DESCRIPTION
the issue didn't occur on Fedora as both cpu and cpu,cpuacct are
linked to the same directory, while it happens if the two subsystems
are mounted separately, such as on Gentoo+openrc.

Closes: https://github.com/giuseppe/crun/issues/35

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>