### PR TITLE
linux: resolve symlinks for bind mounts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,8 @@ libcrun_la_SOURCES = src/libcrun/utils.c \
 			src/libcrun/error.c \
 			src/libcrun/status.c \
 			src/libcrun/terminal.c \
-			src/libcrun/sig2str.c
+			src/libcrun/sig2str.c \
+			src/libcrun/chroot_realpath.c
 
 libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src
 libcrun_la_LIBADD = libocispec/libocispec.la

--- a/cfg.mk
+++ b/cfg.mk
@@ -1,9 +1,10 @@
-export VC_LIST_EXCEPT_DEFAULT=^(lib/.*|m4/.*|md5/.*|build-aux/.*|src/gettext\.h|.*ChangeLog|src/libcrun/cloned_binary.c)$$
+export VC_LIST_EXCEPT_DEFAULT=^(lib/.*|m4/.*|md5/.*|build-aux/.*|src/gettext\.h|.*ChangeLog|src/libcrun/cloned_binary.c|src/libcrun/chroot_realpath.c)$$
 
 local-checks-to-skip = \
     sc_immutable_NEWS \
     sc_copyright_check \
     \
+    sc_prohibit_path_max_allocation \
     sc_prohibit_strcmp \
     sc_program_name \
     sc_bindtextdomain	 \

--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -1,0 +1,168 @@
+/*
+ * chroot_realpath.c -- reslove pathname as if inside chroot
+ * Based on realpath.c Copyright (C) 1993 Rick Sladkey <jrs@world.std.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; see the file COPYING.LIB.  If not,
+ * write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * 2005/09/12: Dan Howell (modified from realpath.c to emulate chroot)
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include <limits.h>				/* for PATH_MAX */
+#include <sys/param.h>			/* for MAXPATHLEN */
+#include <errno.h>
+#ifndef __set_errno
+#define __set_errno(val) ((errno) = (val))
+#endif
+
+#include <sys/stat.h>			/* for S_IFLNK */
+
+#ifndef PATH_MAX
+#define PATH_MAX _POSIX_PATH_MAX
+#endif
+
+#define MAX_READLINKS 32
+
+char *chroot_realpath(const char *chroot, const char *path, char resolved_path[])
+{
+	char copy_path[PATH_MAX];
+	char link_path[PATH_MAX];
+	char got_path[PATH_MAX];
+	char *got_path_root = got_path;
+	char *new_path = got_path;
+	char *max_path;
+	int readlinks = 0;
+	int n;
+	int chroot_len;
+
+	/* Trivial case. */
+	if (chroot == NULL || *chroot == '\0' ||
+	    (*chroot == '/' && chroot[1] == '\0')) {
+		strcpy(resolved_path, path);
+		return resolved_path;
+	}
+
+	chroot_len = strlen(chroot);
+
+	if (chroot_len + strlen(path) >= PATH_MAX - 3) {
+		__set_errno(ENAMETOOLONG);
+		return NULL;
+	}
+
+	/* Make a copy of the source path since we may need to modify it. */
+	strcpy(copy_path, path);
+	path = copy_path;
+	max_path = copy_path + PATH_MAX - chroot_len - 3;
+
+	/* Start with the chroot path. */
+	strcpy(new_path, chroot);
+	new_path += chroot_len;
+	while (*new_path == '/' && new_path > got_path)
+		new_path--;
+	got_path_root = new_path;
+	*new_path++ = '/';
+
+	/* Expand each slash-separated pathname component. */
+	while (*path != '\0') {
+		/* Ignore stray "/". */
+		if (*path == '/') {
+			path++;
+			continue;
+		}
+		if (*path == '.') {
+			/* Ignore ".". */
+			if (path[1] == '\0' || path[1] == '/') {
+				path++;
+				continue;
+			}
+			if (path[1] == '.') {
+				if (path[2] == '\0' || path[2] == '/') {
+					path += 2;
+					/* Ignore ".." at root. */
+					if (new_path == got_path_root + 1)
+						continue;
+					/* Handle ".." by backing up. */
+					while ((--new_path)[-1] != '/');
+					continue;
+				}
+			}
+		}
+		/* Safely copy the next pathname component. */
+		while (*path != '\0' && *path != '/') {
+			if (path > max_path) {
+				__set_errno(ENAMETOOLONG);
+				return NULL;
+			}
+			*new_path++ = *path++;
+		}
+		if (*path == '\0')
+			/* Don't follow symlink for last pathname component. */
+			break;
+#ifdef S_IFLNK
+		/* Protect against infinite loops. */
+		if (readlinks++ > MAX_READLINKS) {
+			__set_errno(ELOOP);
+			return NULL;
+		}
+		/* See if latest pathname component is a symlink. */
+		*new_path = '\0';
+		n = readlink(got_path, link_path, PATH_MAX - 1);
+		if (n < 0) {
+			/* EINVAL means the file exists but isn't a symlink. */
+			if (errno != EINVAL) {
+				/* Make sure it's null terminated. */
+				*new_path = '\0';
+				strcpy(resolved_path, got_path);
+				return NULL;
+			}
+		} else {
+			/* Note: readlink doesn't add the null byte. */
+			link_path[n] = '\0';
+			if (*link_path == '/')
+				/* Start over for an absolute symlink. */
+				new_path = got_path_root;
+			else
+				/* Otherwise back up over this component. */
+				while (*(--new_path) != '/');
+			/* Safe sex check. */
+			if (strlen(path) + n >= PATH_MAX - 2) {
+				__set_errno(ENAMETOOLONG);
+				return NULL;
+			}
+			/* Insert symlink contents into path. */
+			strcat(link_path, path);
+			strcpy(copy_path, link_path);
+			path = copy_path;
+		}
+#endif							/* S_IFLNK */
+		*new_path++ = '/';
+	}
+	/* Delete trailing slash but don't whomp a lone slash. */
+	if (new_path != got_path + 1 && new_path[-1] == '/')
+		new_path--;
+	/* Make sure it's null terminated. */
+	*new_path = '\0';
+	strcpy(resolved_path, got_path);
+	return resolved_path;
+}

--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -18,6 +18,7 @@
  * Boston, MA 02111-1307, USA.
  *
  * 2005/09/12: Dan Howell (modified from realpath.c to emulate chroot)
+ * 2019/04/19: Giuseppe Scrivano (on ENOENT return the part that could be resolved)
  */
 
 #ifdef HAVE_CONFIG_H
@@ -129,6 +130,11 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 		*new_path = '\0';
 		n = readlink(got_path, link_path, PATH_MAX - 1);
 		if (n < 0) {
+			/* If a component doesn't exist, then return what we could translate. */
+			if (errno == ENOENT) {
+				sprintf (resolved_path, "%s%s%s", got_path, path[0] == '/' ? "" : "/", path);
+				return resolved_path;
+			}
 			/* EINVAL means the file exists but isn't a symlink. */
 			if (errno != EINVAL) {
 				/* Make sure it's null terminated. */

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM fedora:latest
 
 ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
@@ -7,6 +7,7 @@ RUN yum install -y golang python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel libselinux-devel go-md2man \
     glibc-static python3-libmount libtool make podman xz nmap-ncat && \
     dnf install -y 'dnf-command(builddep)' && dnf builddep -y podman && \
+    yum downgrade -y runc && \
     go get github.com/onsi/ginkgo/ginkgo && \
     go get github.com/onsi/gomega/... && \
     mkdir -p /root/go/src/github.com/containers && \


### PR DESCRIPTION
resolve symlinks in the target.  It solves an issue when running
Kubernetes as secrets are mounted to /var/run, but it is a symlink
to /run.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>