### PR TITLE
cgroup: enable only the controllers needed

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -832,7 +832,7 @@ libcrun_cgroup_enter (int cgroup_mode, char **path, const char *cgroup_path, int
       return ret;
     }
 
-  if (rootless > 0)
+  if (rootless > 0 && cgroup_mode != CGROUP_MODE_UNIFIED)
     {
       free (*path);
       *path = NULL;

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -29,7 +29,7 @@ enum
   };
 
 int libcrun_get_cgroup_mode (libcrun_error_t *err);
-int libcrun_cgroup_enter (int cgroup_mode, char **path, const char *cgroup_path, int systemd, pid_t pid, const char *id, libcrun_error_t *err);
+int libcrun_cgroup_enter (oci_container_linux_resources *resources, int cgroup_mode, char **path, const char *cgroup_path, int systemd, pid_t pid, const char *id, libcrun_error_t *err);
 int libcrun_cgroup_killall (char *path, libcrun_error_t *err);
 int libcrun_cgroup_destroy (const char *id, char *path, int systemd_cgroup, libcrun_error_t *err);
 int libcrun_move_process_to_cgroup (pid_t pid, char *path, libcrun_error_t *err);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1213,7 +1213,7 @@ libcrun_container_run_internal (libcrun_container *container, struct libcrun_con
   if (cgroup_mode < 0)
     return cgroup_mode;
 
-  ret = libcrun_cgroup_enter (cgroup_mode, &cgroup_path, def->linux ? def->linux->cgroups_path : "", context->systemd_cgroup, pid, context->id, err);
+  ret = libcrun_cgroup_enter (def->linux ? def->linux->resources : NULL, cgroup_mode, &cgroup_path, def->linux ? def->linux->cgroups_path : "", context->systemd_cgroup, pid, context->id, err);
   if (UNLIKELY (ret < 0))
     {
       cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd);


### PR DESCRIPTION
only the root user can enable all the controllers for the unprivileged users.  Change it to request only the controllers we need.

In the cgroup v2 unified mode, systemd enables by default the pids and memory controllers, an unprivileged user can use them without any change to the system configuration.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>
