### PR TITLE
notify: support NOTIFY_SOCKET with create/start

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1178,6 +1178,10 @@ libcrun_do_pivot_root (libcrun_container_t *container, const char *rootfs, libcr
         return crun_make_error (err, errno, "chroot to '%s'", rootfs);
     }
 
+  ret = chdir ("/");
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "chdir to /");
+
   return 0;
 }
 

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -35,9 +35,9 @@ pid_t libcrun_run_linux_container (libcrun_container_t *container,
                                    int detach,
                                    container_entrypoint_t entrypoint,
                                    void *args,
-                                   int *notify_socket_out,
                                    int *sync_socket_out,
                                    libcrun_error_t *err);
+int get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *notify_socket_out, libcrun_error_t *err);
 int libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_error_t *err);
 int libcrun_do_pivot_root (libcrun_container_t *container, const char *rootfs, libcrun_error_t *err);
 int libcrun_set_usernamespace (libcrun_container_t *container, pid_t pid, libcrun_error_t *err);

--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -29,7 +29,6 @@ export TMPDIR=/var/tmp
 #
 # - systemd
 # - notify_socket
-#   must fix NOTIFY_PATH support in crun.  upstream runc doesn't support it as well :-) https://github.com/opencontainers/runc/pull/1807
 #
 # - podman run exit 12*|podman run exit code on failure to exec|failed to start
 #   assumption that "create" must fail if the executable is not found.  We must add lookup for the executable in $PATH to mimic the runc behavior.


### PR DESCRIPTION
mount the parent directory, so that the socket can be created by
"start".  "start" will then wait until it receives the notification
that the container is ready.

Closes: https://github.com/giuseppe/crun/issues/12

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>