### PR TITLE
crun: add new option --cgroup-manager=MANAGER

### DIFF
--- a/crun.1.md
+++ b/crun.1.md
@@ -97,6 +97,10 @@ Defines where to store the state for crun containers.
 Use systemd for configuring cgroups.  If not specified, the cgroup is
 created directly using the cgroupfs backend.
 
+**--cgroup-manager=MANAGER**
+Specify what cgroup manager must be used.  Permitted values are **cgroupfs**,
+**systemd** and **disabled**.
+
 **-?**, **--help**
 Print a help list.
 

--- a/src/crun.h
+++ b/src/crun.h
@@ -29,6 +29,7 @@ struct crun_global_arguments
   bool command;
   bool debug;
   bool option_systemd_cgroup;
+  bool option_force_no_cgroup;
 };
 
 int init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global_arguments *glob, libcrun_error_t *err);

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -511,14 +511,17 @@ int enter_systemd_cgroup_scope (oci_container_linux_resources *resources, const 
 
   i = 0;
   boolean_opts[i++] = "Delegate";
-  if (resources->cpu)
-    boolean_opts[i++] = "CPUAccounting";
-  if (resources->memory)
-    boolean_opts[i++] = "MemoryAccounting";
-  if (resources->block_io)
-    boolean_opts[i++] = "IOAccounting";
-  if (resources->pids)
-    boolean_opts[i++] = "TasksAccounting";
+  if (resources)
+    {
+      if (resources->cpu)
+        boolean_opts[i++] = "CPUAccounting";
+      if (resources->memory)
+        boolean_opts[i++] = "MemoryAccounting";
+      if (resources->block_io)
+        boolean_opts[i++] = "IOAccounting";
+      if (resources->pids)
+        boolean_opts[i++] = "TasksAccounting";
+    }
   boolean_opts[i++] = NULL;
 
   sd_err = sd_bus_default (&bus);

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -28,10 +28,17 @@ enum
    CGROUP_MODE_HYBRID
   };
 
+enum
+  {
+   CGROUP_MANAGER_CGROUPFS = 1,
+   CGROUP_MANAGER_SYSTEMD,
+   CGROUP_MANAGER_DISABLED
+  };
+
 int libcrun_get_cgroup_mode (libcrun_error_t *err);
-int libcrun_cgroup_enter (oci_container_linux_resources *resources, int cgroup_mode, char **path, const char *cgroup_path, int systemd, pid_t pid, const char *id, libcrun_error_t *err);
+int libcrun_cgroup_enter (oci_container_linux_resources *resources, int cgroup_mode, char **path, const char *cgroup_path, int manager, pid_t pid, const char *id, libcrun_error_t *err);
 int libcrun_cgroup_killall (char *path, libcrun_error_t *err);
-int libcrun_cgroup_destroy (const char *id, char *path, int systemd_cgroup, libcrun_error_t *err);
+int libcrun_cgroup_destroy (const char *id, char *path, int manager, libcrun_error_t *err);
 int libcrun_move_process_to_cgroup (pid_t pid, char *path, libcrun_error_t *err);
 int libcrun_update_cgroup_resources (int cgroup_mode, oci_container_linux_resources *resources, char *path, libcrun_error_t *err);
 int libcrun_cgroups_create_symlinks (const char *target, libcrun_error_t *err);

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -42,6 +42,7 @@ struct libcrun_context_s
   bool detach;
   bool no_subreaper;
   bool no_new_keyring;
+  bool force_no_cgroup;
 };
 
 enum


### PR DESCRIPTION
It supports to specify what cgroup manager must be used.  The accepted values are: cgroupfs, systemd and disabled.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>
